### PR TITLE
请升级com.xuxueli:xxl-job-core组件版本以解决2个安全漏洞

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -103,7 +103,7 @@
             <dependency>
                 <groupId>com.xuxueli</groupId>
                 <artifactId>xxl-job-core</artifactId>
-                <version>2.2.0</version>
+                <version>2.3.0</version>
             </dependency>
 
             <dependency>


### PR DESCRIPTION
将 **com.xuxueli:xxl-job-core** 组件从2.2.0 版本升级至 2.3.0版本,
用于修复以下安全漏洞：


序号 | 漏洞编号 | 漏洞标题 | 漏洞级别
-- | -- | -- | --
1 | [MPS-2022-57270](https://www.oscs1024.com/hd/MPS-2022-57270) | xuxueli xxl-job 存在命令注入漏洞 | 严重
2 | [MPS-2023-5196](https://www.oscs1024.com/hd/MPS-2023-5196) | xxl-job 存在存储型XSS漏洞 | 中危
  |   |   |   


<br/>

_注意 ：此 PR 由您（或拥有此仓库权限的其他维护者）授权 [墨菲安全](https://www.murphysec.com) 打开_

了解更多：
- [如何快速修复代码安全问题](https://www.murphysec.com/docs/faqs/security-issues/how-to-quick-fixes.html)
